### PR TITLE
Updated spam filter accounting of attachments

### DIFF
--- a/CHEF/Components/Commands/Spam/SpamConfig.cs
+++ b/CHEF/Components/Commands/Spam/SpamConfig.cs
@@ -28,6 +28,8 @@ namespace CHEF.Components.Commands.Spam
                 embedBuilder.AddField(nameof(SpamFilterConfig.MessagesForAction), config.MessagesForAction.ToString());
                 embedBuilder.AddField(nameof(SpamFilterConfig.MessageSecondsGap), config.MessageSecondsGap.ToString());
                 embedBuilder.AddField(nameof(SpamFilterConfig.IncludeMessageContentInLog), config.IncludeMessageContentInLog.ToString());
+                embedBuilder.AddField(nameof(SpamFilterConfig.AttachmentCountForSpam), config.AttachmentCountForSpam.ToString());
+                embedBuilder.AddField(nameof(SpamFilterConfig.EmbedCountForSpam), config.EmbedCountForSpam.ToString());
                 await ReplyAsync("", false, embedBuilder.Build());
             }
         }
@@ -89,6 +91,22 @@ namespace CHEF.Components.Commands.Spam
                             includeMessageContentInLog = includeMessageContentInLogInt == 1;
                         }
                         config.IncludeMessageContentInLog = includeMessageContentInLog;
+                        break;
+                    case "attachmentcountforspam":
+                        if (!int.TryParse(value, out var attachmentCountforSpam) || attachmentCountforSpam < 1)
+                        {
+                            await ReplyAsync($"Value should be an integer and more than 0");
+                            return;
+                        }
+                        config.AttachmentCountForSpam = attachmentCountforSpam;
+                        break;
+                    case "embedcountforspam":
+                        if (!int.TryParse(value, out var embedCountForSpam) || embedCountForSpam < 1)
+                        {
+                            await ReplyAsync($"Value should be an integer and more than 0");
+                            return;
+                        }
+                        config.EmbedCountForSpam = embedCountForSpam;
                         break;
                     default:
                         await ReplyAsync($"**{fieldName}** is not a valid field");

--- a/CHEF/Components/Watcher/Spam/SpamFilter.cs
+++ b/CHEF/Components/Watcher/Spam/SpamFilter.cs
@@ -132,13 +132,13 @@ namespace CHEF.Components.Watcher.Spam
                 using (var md5 = new HMACMD5(md5Key))
                 {
                     var builder = new StringBuilder(msg.Content);
-                    foreach (var attachment in msg.Attachments)
+                    if (msg.Attachments.Count >= config.AttachmentCountForSpam)
                     {
-                        builder.Append(attachment.Url);
+                        builder.Append($" {msg.Attachments.Count} attachments");
                     }
-                    foreach (var embed in msg.Embeds)
+                    if (msg.Embeds.Count >= config.EmbedCountForSpam)
                     {
-                        builder.Append(embed.Title).Append(embed.Description).Append(embed.Footer).Append(embed.Url);
+                        builder.Append($" {msg.Attachments.Count} embeds");
                     }
 
                     var hash = new HashResult(md5.ComputeHash(Encoding.UTF8.GetBytes(builder.ToString())));

--- a/CHEF/Components/Watcher/Spam/SpamFilterConfig.cs
+++ b/CHEF/Components/Watcher/Spam/SpamFilterConfig.cs
@@ -11,5 +11,7 @@ namespace CHEF.Components.Watcher.Spam
         public int MessagesForAction { get; set; }
         public int MessageSecondsGap { get; set; }
         public bool IncludeMessageContentInLog { get; set; }
+        public int AttachmentCountForSpam { get; set; }
+        public int EmbedCountForSpam { get; set; }
     }
 }

--- a/CHEF/Migrations/SpamIgnoreRoles/20260129150256_SpamAttachmentCount.Designer.cs
+++ b/CHEF/Migrations/SpamIgnoreRoles/20260129150256_SpamAttachmentCount.Designer.cs
@@ -2,6 +2,7 @@
 using CHEF.Components.Watcher.Spam;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -10,9 +11,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CHEF.Migrations.SpamIgnoreRoles
 {
     [DbContext(typeof(SpamFilterContext))]
-    partial class SpamIgnoreRolesContextModelSnapshot : ModelSnapshot
+    [Migration("20260129150256_SpamAttachmentCount")]
+    partial class SpamAttachmentCount
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CHEF/Migrations/SpamIgnoreRoles/20260129150256_SpamAttachmentCount.cs
+++ b/CHEF/Migrations/SpamIgnoreRoles/20260129150256_SpamAttachmentCount.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CHEF.Migrations.SpamIgnoreRoles
+{
+    public partial class SpamAttachmentCount : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "attachment_count_for_spam",
+                table: "spam_filter_configs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 4);
+
+            migrationBuilder.AddColumn<int>(
+                name: "embed_count_for_spam",
+                table: "spam_filter_configs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 4);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "attachment_count_for_spam",
+                table: "spam_filter_configs");
+
+            migrationBuilder.DropColumn(
+                name: "embed_count_for_spam",
+                table: "spam_filter_configs");
+        }
+    }
+}


### PR DESCRIPTION
Got motivated enough by bots to update spam filter.
The previous way of counting attachments and embeds by url basically never works, since the same image uploaded multiple times would have different urls. Now it will check for the same amout of attachments, it should now be able to catch those 4-image bots, while not having much (or any) more false-positives. All the other rules still apply.
The amount of attachments (and embeds) is configurable through the same command as other fields, but default value in the migration (4) should be fine for now.