### PR TITLE
Spam filter old behaviour for attachments below limit

### DIFF
--- a/CHEF/Components/Watcher/Spam/SpamFilter.cs
+++ b/CHEF/Components/Watcher/Spam/SpamFilter.cs
@@ -136,9 +136,24 @@ namespace CHEF.Components.Watcher.Spam
                     {
                         builder.Append($" {msg.Attachments.Count} attachments");
                     }
+                    else
+                    {
+                        foreach (var attachment in msg.Attachments)
+                        {
+                            builder.Append(attachment.Url);
+                        }
+                    }
+
                     if (msg.Embeds.Count >= config.EmbedCountForSpam)
                     {
                         builder.Append($" {msg.Attachments.Count} embeds");
+                    }
+                    else
+                    {
+                        foreach (var embed in msg.Embeds)
+                        {
+                            builder.Append(embed.Title).Append(embed.Description).Append(embed.Footer).Append(embed.Url);
+                        }
                     }
 
                     var hash = new HashResult(md5.ComputeHash(Encoding.UTF8.GetBytes(builder.ToString())));


### PR DESCRIPTION
I thought about it a bit more and actually my change made it so below the limit all messages with only attachments would count the same, which was not the intention. So I restored old behaviour with urls if attachment count is below the limit.