### PR TITLE
LangVersion lock, Timeout action

### DIFF
--- a/CHEF/CHEF.csproj
+++ b/CHEF/CHEF.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>13</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/CHEF/Components/Commands/Spam/SpamConfig.cs
+++ b/CHEF/Components/Commands/Spam/SpamConfig.cs
@@ -30,6 +30,7 @@ namespace CHEF.Components.Commands.Spam
                 embedBuilder.AddField(nameof(SpamFilterConfig.IncludeMessageContentInLog), config.IncludeMessageContentInLog.ToString());
                 embedBuilder.AddField(nameof(SpamFilterConfig.AttachmentCountForSpam), config.AttachmentCountForSpam.ToString());
                 embedBuilder.AddField(nameof(SpamFilterConfig.EmbedCountForSpam), config.EmbedCountForSpam.ToString());
+                embedBuilder.AddField(nameof(SpamFilterConfig.TimeoutDuration), config.TimeoutDuration.ToString());
                 await ReplyAsync("", false, embedBuilder.Build());
             }
         }
@@ -107,6 +108,14 @@ namespace CHEF.Components.Commands.Spam
                             return;
                         }
                         config.EmbedCountForSpam = embedCountForSpam;
+                        break;
+                    case "timeoutduration":
+                        if (!int.TryParse(value, out var timeoutDuration) || timeoutDuration < 1)
+                        {
+                            await ReplyAsync($"Value should be an integer and more than 0");
+                            return;
+                        }
+                        config.TimeoutDuration = timeoutDuration;
                         break;
                     default:
                         await ReplyAsync($"**{fieldName}** is not a valid field");

--- a/CHEF/Components/Watcher/Spam/ActionOnSpam.cs
+++ b/CHEF/Components/Watcher/Spam/ActionOnSpam.cs
@@ -9,5 +9,6 @@ namespace CHEF.Components.Watcher.Spam
         Mute,
         Kick,
         Ban,
+        Timeout,
     }
 }

--- a/CHEF/Components/Watcher/Spam/SpamFilter.cs
+++ b/CHEF/Components/Watcher/Spam/SpamFilter.cs
@@ -201,6 +201,12 @@ namespace CHEF.Components.Watcher.Spam
 
                                 await guild.AddBanAsync(author, 1, auditReason);
                                 break;
+                            case ActionOnSpam.Timeout:
+                                Logger.Log($"Spam timeout user {guildUser.Nickname} : {auditReason}");
+
+                                await guildUser.SetTimeOutAsync(TimeSpan.FromDays(config.TimeoutDuration), new RequestOptions { AuditLogReason = auditReason });
+                                await DeleteUserMessages(guild, guildUser, config);
+                                break;
                         }
                         return true;
                     }

--- a/CHEF/Components/Watcher/Spam/SpamFilterConfig.cs
+++ b/CHEF/Components/Watcher/Spam/SpamFilterConfig.cs
@@ -13,5 +13,6 @@ namespace CHEF.Components.Watcher.Spam
         public bool IncludeMessageContentInLog { get; set; }
         public int AttachmentCountForSpam { get; set; }
         public int EmbedCountForSpam { get; set; }
+        public int TimeoutDuration { get; set; }
     }
 }

--- a/CHEF/Components/Watcher/Spam/SpamFilterContext.cs
+++ b/CHEF/Components/Watcher/Spam/SpamFilterContext.cs
@@ -51,6 +51,9 @@ namespace CHEF.Components.Watcher.Spam
                 MessageSecondsGap = 15,
                 IncludeMessageContentInLog = true,
                 MuteRoleId = 0,
+                AttachmentCountForSpam = 4,
+                EmbedCountForSpam = 4,
+                TimeoutDuration = 7
             };
         }
 

--- a/CHEF/Migrations/SpamIgnoreRoles/20260429165147_Timeout.Designer.cs
+++ b/CHEF/Migrations/SpamIgnoreRoles/20260429165147_Timeout.Designer.cs
@@ -2,6 +2,7 @@
 using CHEF.Components.Watcher.Spam;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -10,9 +11,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CHEF.Migrations.SpamIgnoreRoles
 {
     [DbContext(typeof(SpamFilterContext))]
-    partial class SpamIgnoreRolesContextModelSnapshot : ModelSnapshot
+    [Migration("20260429165147_Timeout")]
+    partial class Timeout
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CHEF/Migrations/SpamIgnoreRoles/20260429165147_Timeout.cs
+++ b/CHEF/Migrations/SpamIgnoreRoles/20260429165147_Timeout.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CHEF.Migrations.SpamIgnoreRoles
+{
+    public partial class Timeout : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "timeout_duration",
+                table: "spam_filter_configs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 7);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "timeout_duration",
+                table: "spam_filter_configs");
+        }
+    }
+}


### PR DESCRIPTION
SpamFilter wasn't working since the last 2 updates. The reason for that was with the latest `LangVersion` querry expression was generated to use `ReadOnlySpan` instead of an array and used version of EF can't understand it, as a fix I locked `LangVersion` to latest working.
```
//LangVersion latest
bool flag = await this.SpamIgnoreRoles.AsQueryable().AnyAsync<SpamIgnoreRole>((Expression<Func<SpamIgnoreRole, bool>>) (el => MemoryExtensions.Contains<ulong>(ReadOnlySpan<ulong>.op_Implicit(ids), el.DiscordId)));
```
```
//LangVersion 13
bool flag = await this.SpamIgnoreRoles.AsQueryable().AnyAsync<SpamIgnoreRole>((Expression<Func<SpamIgnoreRole, bool>>) (el => ids.Contains<ulong>(el.DiscordId)));
```
Also added `Timeout` action just for the completion since discord does support it. Requires special permission if it will be used.